### PR TITLE
added dependency check to ccs build and a stand-alone dependency check action

### DIFF
--- a/.github/workflows/ccs-build.yml
+++ b/.github/workflows/ccs-build.yml
@@ -51,7 +51,7 @@ jobs:
   check_dependencies:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
-    name: Check Dependencies Action
+    name: Check Dependencies
     steps:
       - name: Check Dependencies
         uses: StaflSystems/CustomGithubActions/CheckDependencies@feature/dependency-check

--- a/.github/workflows/ccs-build.yml
+++ b/.github/workflows/ccs-build.yml
@@ -48,8 +48,18 @@ jobs:
         extensions: 'h,cpp'
         clangFormatVersion: 12
 
+  check_dependencies_action:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Check Dependencies Action
+    steps:
+      uses: StaflSystems/CustomGithubActions/CheckDependencies@feature/dependency-check
+      with:
+        STAFL_CI_PRIVATE_KEY: ${{ secrets.STAFL_CI_PRIVATE_KEY }}
+
   check_dependencies:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
     name: Check Dependencies
     steps:
       - name: Get Auth Token
@@ -61,6 +71,7 @@ jobs:
       - uses: gregsdennis/dependencies-action@main
         env:
           GITHUB_TOKEN: ${{ steps.get-auth-token.outputs.token }}
+    
     
   build:
     runs-on: self-hosted

--- a/.github/workflows/ccs-build.yml
+++ b/.github/workflows/ccs-build.yml
@@ -32,7 +32,7 @@ on:
         value: ${{ jobs.build.outputs.tag_version }}
 
     secrets:
-      STAFL_CI_TOKEN:
+      STAFL_CI_PRIVATE_KEY:
         required: true
         description: access token for dependency checking
 

--- a/.github/workflows/ccs-build.yml
+++ b/.github/workflows/ccs-build.yml
@@ -31,6 +31,11 @@ on:
         description: version number of tag
         value: ${{ jobs.build.outputs.tag_version }}
 
+    secrets:
+      STAFL_CI_TOKEN:
+        required: true
+        description: access token for dependency checking
+
 jobs:
   format:
     runs-on: ubuntu-latest
@@ -42,6 +47,15 @@ jobs:
         exclude: ${{ inputs.format-exclude }}
         extensions: 'h,cpp'
         clangFormatVersion: 12
+
+  check_dependencies:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Check Dependencies
+    steps:
+    - uses: gregsdennis/dependencies-action@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.STAFL_CI_TOKEN }}
     
   build:
     runs-on: self-hosted

--- a/.github/workflows/ccs-build.yml
+++ b/.github/workflows/ccs-build.yml
@@ -50,12 +50,17 @@ jobs:
 
   check_dependencies:
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
     name: Check Dependencies
     steps:
-    - uses: gregsdennis/dependencies-action@main
-      env:
-        GITHUB_TOKEN: ${{ secrets.STAFL_CI_TOKEN }}
+      - name: Get Auth Token
+        id: get-auth-token
+        run: |
+          echo "${{ secrets.STAFL_CI_PRIVATE_KEY }}" > key.pem
+          TOKEN=`npx https://github.com/StaflSystems/github-app-installation-access-token get -a 159011 -i 21323630 -k "@key.pem"`
+          echo "::set-output name=token::$TOKEN"
+      - uses: gregsdennis/dependencies-action@main
+        env:
+          GITHUB_TOKEN: ${{ steps.get-auth-token.outputs.token }}
     
   build:
     runs-on: self-hosted

--- a/.github/workflows/ccs-build.yml
+++ b/.github/workflows/ccs-build.yml
@@ -48,7 +48,7 @@ jobs:
         extensions: 'h,cpp'
         clangFormatVersion: 12
 
-  check_dependencies_action:
+  check_dependencies:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' }}
     name: Check Dependencies Action
@@ -56,23 +56,7 @@ jobs:
       - name: Check Dependencies
         uses: StaflSystems/CustomGithubActions/CheckDependencies@feature/dependency-check
         with:
-          STAFL_CI_PRIVATE_KEY: ${{ secrets.STAFL_CI_PRIVATE_KEY }}
-
-  check_dependencies:
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
-    name: Check Dependencies
-    steps:
-      - name: Get Auth Token
-        id: get-auth-token
-        run: |
-          echo "${{ secrets.STAFL_CI_PRIVATE_KEY }}" > key.pem
-          TOKEN=`npx https://github.com/StaflSystems/github-app-installation-access-token get -a 159011 -i 21323630 -k "@key.pem"`
-          echo "::set-output name=token::$TOKEN"
-      - uses: gregsdennis/dependencies-action@main
-        env:
-          GITHUB_TOKEN: ${{ steps.get-auth-token.outputs.token }}
-    
+          STAFL_CI_PRIVATE_KEY: ${{ secrets.STAFL_CI_PRIVATE_KEY }}   
     
   build:
     runs-on: self-hosted

--- a/.github/workflows/ccs-build.yml
+++ b/.github/workflows/ccs-build.yml
@@ -53,9 +53,10 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     name: Check Dependencies Action
     steps:
-      uses: StaflSystems/CustomGithubActions/CheckDependencies@feature/dependency-check
-      with:
-        STAFL_CI_PRIVATE_KEY: ${{ secrets.STAFL_CI_PRIVATE_KEY }}
+      - name: Check Dependencies
+        uses: StaflSystems/CustomGithubActions/CheckDependencies@feature/dependency-check
+        with:
+          STAFL_CI_PRIVATE_KEY: ${{ secrets.STAFL_CI_PRIVATE_KEY }}
 
   check_dependencies:
     runs-on: ubuntu-latest

--- a/.github/workflows/cmake-embedded.yml
+++ b/.github/workflows/cmake-embedded.yml
@@ -44,6 +44,16 @@ jobs:
 #         message: 'Committing clang-format changes'
 #       env:
 #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  check_dependencies:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Check Dependencies
+    steps:
+      - name: Check Dependencies
+        uses: StaflSystems/CustomGithubActions/CheckDependencies@feature/dependency-check
+        with:
+          STAFL_CI_PRIVATE_KEY: ${{ secrets.STAFL_CI_PRIVATE_KEY }}   
         
   build:
     # The CMake configure and build commands are platform agnostic and should work equally well on Windows or Mac.

--- a/.github/workflows/cmake-embedded.yml
+++ b/.github/workflows/cmake-embedded.yml
@@ -22,6 +22,9 @@ on:
       ACTIONS_SSH_PRIVATE_KEY:
         required: true
         description: private key
+      STAFL_CI_PRIVATE_KEY:
+        required: true
+        description: access token for dependency checking
 
 jobs:
   format:

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,15 +1,16 @@
-on: 
-  workflow_call:
-    secrets:
-      STAFL_CI_TOKEN:
-        required: true
-        description: access token for dependency checking
+on: [workflow_call]
 
 jobs:
   check_dependencies:
     runs-on: ubuntu-latest
     name: Check Dependencies
     steps:
-    - uses: gregsdennis/dependencies-action@main
-      env:
-        GITHUB_TOKEN: ${{ secrets.STAFL_CI_TOKEN }}
+      - name: Get Auth Token
+        id: get-auth-token
+        run: |
+          echo "${{ secrets.STAFL_CI_PRIVATE_KEY }}" > key.pem
+          TOKEN=`npx https://github.com/StaflSystems/github-app-installation-access-token get -a 159011 -i 21323630 -k "@key.pem"`
+          echo "::set-output name=token::$TOKEN"
+      - uses: gregsdennis/dependencies-action@main
+        env:
+          GITHUB_TOKEN: ${{ steps.get-auth-token.outputs.token }}

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,0 +1,15 @@
+on: 
+  workflow_call:
+    secrets:
+      STAFL_CI_TOKEN:
+        required: true
+        description: access token for dependency checking
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+    name: Check Dependencies
+    steps:
+    - uses: gregsdennis/dependencies-action@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.STAFL_CI_TOKEN }}

--- a/CheckDependencies/action.yml
+++ b/CheckDependencies/action.yml
@@ -11,6 +11,7 @@ runs:
   using: composite
   steps:
     - name: Get Auth Token
+      shell: bash
       id: get-auth-token
       run: |
         echo "${{ inputs.STAFL_CI_PRIVATE_KEY }}" > key.pem

--- a/CheckDependencies/action.yml
+++ b/CheckDependencies/action.yml
@@ -1,0 +1,23 @@
+name: Check Code Review Dependencies
+description: This action checks for coede review dependencies documented in the first comment of a PR
+author: thebhef
+
+inputs:
+  STAFL_CI_PRIVATE_KEY:
+    required: true
+    description: access token for checking dependencies in all Stafl Systems repos
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+    name: Check Dependencies
+    steps:
+      - name: Get Auth Token
+        id: get-auth-token
+        run: |
+          echo "${{ inputs.STAFL_CI_PRIVATE_KEY }}" > key.pem
+          TOKEN=`npx https://github.com/StaflSystems/github-app-installation-access-token get -a 159011 -i 21323630 -k "@key.pem"`
+          echo "::set-output name=token::$TOKEN"
+      - uses: gregsdennis/dependencies-action@main
+        env:
+          GITHUB_TOKEN: ${{ steps.get-auth-token.outputs.token }}

--- a/CheckDependencies/action.yml
+++ b/CheckDependencies/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
     description: access token for checking dependencies in all Stafl Systems repos
 
-jobs:
+runs:
   check_dependencies:
     runs-on: ubuntu-latest
     name: Check Dependencies

--- a/CheckDependencies/action.yml
+++ b/CheckDependencies/action.yml
@@ -8,16 +8,14 @@ inputs:
     description: access token for checking dependencies in all Stafl Systems repos
 
 runs:
-  check_dependencies:
-    runs-on: ubuntu-latest
-    name: Check Dependencies
-    steps:
-      - name: Get Auth Token
-        id: get-auth-token
-        run: |
-          echo "${{ inputs.STAFL_CI_PRIVATE_KEY }}" > key.pem
-          TOKEN=`npx https://github.com/StaflSystems/github-app-installation-access-token get -a 159011 -i 21323630 -k "@key.pem"`
-          echo "::set-output name=token::$TOKEN"
-      - uses: gregsdennis/dependencies-action@main
-        env:
-          GITHUB_TOKEN: ${{ steps.get-auth-token.outputs.token }}
+  using: composite
+  steps:
+    - name: Get Auth Token
+      id: get-auth-token
+      run: |
+        echo "${{ inputs.STAFL_CI_PRIVATE_KEY }}" > key.pem
+        TOKEN=`npx https://github.com/StaflSystems/github-app-installation-access-token get -a 159011 -i 21323630 -k "@key.pem"`
+        echo "::set-output name=token::$TOKEN"
+    - uses: gregsdennis/dependencies-action@main
+      env:
+        GITHUB_TOKEN: ${{ steps.get-auth-token.outputs.token }}


### PR DESCRIPTION
See readme here: https://github.com/gregsdennis/dependencies-action

Basically add `depends on <link-to-PR>` for PRs in other repos or `depends on PR#` for same repo

NOTE: This does add another arg to the CCS build. Provide `secrets.STAFL_CI_PRIVATE_KEY` for the `STAFL_CI_PRIVATE_KEY` secret argument to fix the issue. See https://staflsystems.atlassian.net/wiki/spaces/EM/pages/213909505/Secret+for+Access+to+Other+Repos for more info.

Also updated https://staflsystems.atlassian.net/wiki/spaces/EM/pages/208240641/PR+Etiquette
to cover this.