### PR TITLE
add custom action to build docsite (ET-761)

### DIFF
--- a/BuildCMakeDocsTarget/README.md
+++ b/BuildCMakeDocsTarget/README.md
@@ -1,0 +1,5 @@
+# Build CMake Docs Target
+
+This action builds a CMake target for documentation, zips up the output, and creates or updates a release's files with the zip file. The tag creation is controlled by the `create-tag` input, and can be disabled for PR builds.
+
+This action can be used as part of a dependent job in an existing workflow that creates a release by using the [`needs` job property](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds).

--- a/BuildCMakeDocsTarget/action.yml
+++ b/BuildCMakeDocsTarget/action.yml
@@ -1,0 +1,50 @@
+name: Build CMake Documentation Target
+description: This action builds release documentation via a CMake target, zips the directory up, and modifies or creates a release to include the .zip file
+author: thebhef
+
+inputs:
+  doc-target:
+    description: the name of the CMake target
+    required: True
+  cmake-directory:
+    description: the directory CMake should use to build
+    required: True
+  doc-output:
+    description: the directory containing the output of the CMake build, relative to CMake-directory
+    required: True
+  build-version:
+    description: the version which should be used for the tag and the name of the zip file
+  
+runs:
+  using: composite
+  steps:
+    # IMPROVEMENT: Update version in document as with the 'Update BuildVersion.h' step in the cmake-embedded build
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: cmake -B ${{cmake-directory}}
+
+    - name: Build documentation target
+      # Build your program with the given configuration
+      run: cmake --build ${{cmake-directory}} --target ${{inputs.doc-target}}
+
+    - name: Zip docs dir
+      id: zip-docs
+      run: |
+        DOCSITE_ZIP=docsite-${{inputs.build-version}}.zip
+        echo ::set-output name=zip-path::${{input.cmake-directory}}/${{input.doc-output}}/../$DOCSITE_ZIP
+        cd ${{input.cmake-directory}}/${{input.doc-output}}
+        zip -r ../$DOCSITE_ZIP . 
+        cd -
+      outputs:
+        zip-path:
+          description: path to zip file
+
+    - name: Create a GitHub release
+      uses: ncipollo/release-action@v1
+      with:
+        allowUpdates: True
+        artifacts: "${{steps.zip-docs.outputs.zip-path}}"
+        tag: ${{inputs.build-version}}
+        commit: ${{ github.sha }}

--- a/BuildCMakeDocsTarget/action.yml
+++ b/BuildCMakeDocsTarget/action.yml
@@ -15,6 +15,9 @@ inputs:
   build-version:
     description: the version which should be used for the tag and the name of the zip file
     required: True
+  create-tag:
+    description: whether to create a tag
+    required: True
   
 runs:
   using: composite
@@ -43,6 +46,7 @@ runs:
         cd -
       
     - name: Create a GitHub release
+      if: ${{inputs.create-tag}}
       uses: ncipollo/release-action@v1
       with:
         allowUpdates: True

--- a/BuildCMakeDocsTarget/action.yml
+++ b/BuildCMakeDocsTarget/action.yml
@@ -40,10 +40,7 @@ runs:
         cd ${{input.cmake-directory}}/${{input.doc-output}}
         zip -r ../$DOCSITE_ZIP . 
         cd -
-      outputs:
-        zip-path:
-          description: path to zip file
-
+      
     - name: Create a GitHub release
       uses: ncipollo/release-action@v1
       with:

--- a/BuildCMakeDocsTarget/action.yml
+++ b/BuildCMakeDocsTarget/action.yml
@@ -24,12 +24,12 @@ runs:
       shell: bash
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{cmake-directory}}
+      run: cmake -B ${{inputs.cmake-directory}}
 
     - name: Build documentation target
       shell: bash
       # Build your program with the given configuration
-      run: cmake --build ${{cmake-directory}} --target ${{inputs.doc-target}}
+      run: cmake --build ${{inputs.cmake-directory}} --target ${{inputs.doc-target}}
 
     - name: Zip docs dir
       shell: bash

--- a/BuildCMakeDocsTarget/action.yml
+++ b/BuildCMakeDocsTarget/action.yml
@@ -5,19 +5,19 @@ author: thebhef
 inputs:
   doc-target:
     description: the name of the CMake target
-    required: True
+    default: docs
   cmake-directory:
     description: the directory CMake should use to build
-    required: True
+    default: build
   doc-output:
     description: the directory containing the output of the CMake build, relative to cmake-directory
-    required: True
+    default: docs/docs/sphinx
   build-version:
     description: the version which should be used for the tag and the name of the zip file
     required: True
   create-tag:
     description: whether to create a tag
-    required: True
+    default: True
   
 runs:
   using: composite
@@ -26,7 +26,7 @@ runs:
       shell: bash
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-      run: cmake -B ${{inputs.cmake-directory}}
+      run: cmake -B ${{inputs.cmake-directory}} -G Ninja
 
     - name: Build documentation target
       shell: bash

--- a/BuildCMakeDocsTarget/action.yml
+++ b/BuildCMakeDocsTarget/action.yml
@@ -21,15 +21,18 @@ runs:
     # IMPROVEMENT: Update version in document as with the 'Update BuildVersion.h' step in the cmake-embedded build
 
     - name: Configure CMake
+      shell: bash
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
       # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
       run: cmake -B ${{cmake-directory}}
 
     - name: Build documentation target
+      shell: bash
       # Build your program with the given configuration
       run: cmake --build ${{cmake-directory}} --target ${{inputs.doc-target}}
 
     - name: Zip docs dir
+      shell: bash
       id: zip-docs
       run: |
         DOCSITE_ZIP=docsite-${{inputs.build-version}}.zip

--- a/BuildCMakeDocsTarget/action.yml
+++ b/BuildCMakeDocsTarget/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: the directory CMake should use to build
     required: True
   doc-output:
-    description: the directory containing the output of the CMake build, relative to CMake-directory
+    description: the directory containing the output of the CMake build, relative to cmake-directory
     required: True
   build-version:
     description: the version which should be used for the tag and the name of the zip file
@@ -22,8 +22,6 @@ inputs:
 runs:
   using: composite
   steps:
-    # IMPROVEMENT: Update version in document as with the 'Update BuildVersion.h' step in the cmake-embedded build
-
     - name: Configure CMake
       shell: bash
       # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.

--- a/BuildCMakeDocsTarget/action.yml
+++ b/BuildCMakeDocsTarget/action.yml
@@ -14,6 +14,7 @@ inputs:
     required: True
   build-version:
     description: the version which should be used for the tag and the name of the zip file
+    required: True
   
 runs:
   using: composite

--- a/BuildCMakeDocsTarget/action.yml
+++ b/BuildCMakeDocsTarget/action.yml
@@ -36,8 +36,8 @@ runs:
       id: zip-docs
       run: |
         DOCSITE_ZIP=docsite-${{inputs.build-version}}.zip
-        echo ::set-output name=zip-path::${{input.cmake-directory}}/${{input.doc-output}}/../$DOCSITE_ZIP
-        cd ${{input.cmake-directory}}/${{input.doc-output}}
+        echo ::set-output name=zip-path::${{inputs.cmake-directory}}/${{inputs.doc-output}}/../$DOCSITE_ZIP
+        cd ${{inputs.cmake-directory}}/${{inputs.doc-output}}
         zip -r ../$DOCSITE_ZIP . 
         cd -
       


### PR DESCRIPTION
# What it is
First used in StaflLib on https://github.com/StaflSystems/StaflLib/pull/247/. There it is dependent upon the `build/build` command. It runs on PRs and does not create commits. When landed on main, the tag created by `build/build` should be updated to include the .zip file.

# Testing
So far I have tested this by passing `true` from a PR build to create a tag.
https://github.com/StaflSystems/StaflLib/releases/tag/0.1.0-PullRequest0247.222