### PR TITLE
exit with exception when version.h isn't found (HON-554)

### DIFF
--- a/WriteBuildVersion/script.py
+++ b/WriteBuildVersion/script.py
@@ -25,7 +25,7 @@ def main(filepath, major, minor, patch, build):
                 print(line.rstrip())
     
     else:
-        print(f"{filepath} not found. Skipping this step")
+        raise FileNotFoundError(f"{filepath} not found.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Change
Throw an exception if the target version.h file isn't found.

# Motivation and Context
I noticed after trying to configure this step on [HON](https://github.com/StaflSystems/honolulu-bms2000/runs/40198134871) that if the version.h isn't found, the WriteBuildVersion action fails silently.